### PR TITLE
adding branch for ngx_aws_auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y install curl build-essential libpcre3 libpcre3-dev zlib1g-dev lib
     curl -LO http://nginx.org/download/nginx-1.9.3.tar.gz && \
     tar zxf nginx-1.9.3.tar.gz && \
     cd nginx-1.9.3 && \
-    git clone https://github.com/anomalizer/ngx_aws_auth.git && \
+    git clone -b AuthV2 https://github.com/anomalizer/ngx_aws_auth.git && \
     ./configure --with-http_ssl_module --add-module=ngx_aws_auth && \
     make install && \
     cd /tmp && \


### PR DESCRIPTION
either we need to use the AuthV2 branch of ngx_aws_auth, or the config file needs to be updated to use the appropriate directives as aws_secret_key is apparently deprecated. 
